### PR TITLE
Few improvements and optimization

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,5 +6,7 @@ declare module "tex-to-svg" {
         em?: number
     }
 
-    export default function TeXToSVG(str: string, opts?: options): string;
+    function TeXToSVG(str: string, opts: options, getWidth: Number): { svgString: string, svgWidth: Number };
+    function TeXToSVG(str: string, opts?: options): string;
+    export default TeXToSVG;
 }


### PR DESCRIPTION
1. Moved document generation out of `TeXToSVG()` to speed up successive lookups.
2. Added the CSS recommended by MathJax:

https://github.com/mathjax/MathJax-demos-node/blob/73bf96e0863a87c39f080b0a7ad50e1c2468823d/direct/tex2svg#L38-L49

3. Added optional `getWidth` argument to get the width of generated SVG.
